### PR TITLE
Detect the user locale with the browser preference

### DIFF
--- a/src/config/useConfig.js
+++ b/src/config/useConfig.js
@@ -4,6 +4,20 @@ import { storage } from './version.json';
 export const STORAGE_KEY =  'Towa_ArkTable_Config';
 export const STORAGE_VERSION = storage;
 
+const detectLocale = () => {
+	const lang = navigator.language;
+	if (lang) {
+		if (lang.startsWith('en')) {
+			return 'en_US';
+		} else if (lang.startsWith('ja')) {
+			return 'ja_JP';
+		} else if (lang.startsWith('ko')) {
+			return 'ko_KR';
+		}
+	}
+	return 'zh_CN';
+};
+
 const default_config = {
 	showAllResources: false,
 	showFocusMaterials: true,
@@ -14,7 +28,7 @@ const default_config = {
 	filters: [],
 	showExp: false,
 	showAnnouncementCodeOnce: false,
-	locale: window.localStorage.getItem('Towa_ArkTable_Lang') || 'zh_CN',
+	locale: window.localStorage.getItem('Towa_ArkTable_Lang') || detectLocale(),
 };
 
 const reducer = (state, action) => {


### PR DESCRIPTION
First of all, thank you for making and maintaining this great website! 😄 

This patch allows detecting the user locale with the browser preference using `navigator.language`.

No difference for the Chinese but should be meaningful for people who shrink back in Chinese.
For instance, one of the famous Japanese wikis is saying "At first, open the setting at the top-right button and set the language 'Japanese'".

https://wiki3.jp/arknightsjp/page/489#ark-nights_com

I'm new to this repository, but I simply thought I might be able to help in some way.
Feel free to tell me if anything I can fix, or even it's okay to ignore my code and rewrite it in your way.

Thanks.