### PR TITLE
[Suggestion] Add input area for each materials in Stock page

### DIFF
--- a/src/components/materialsGroup/index.js
+++ b/src/components/materialsGroup/index.js
@@ -2,6 +2,7 @@ import React from 'preact';
 import style from './style';
 
 import ArkItem from '../item';
+import ArkInputCell from '../inputCell';
 
 const ArkMaterialGroup = ({
 	ir,
@@ -10,6 +11,7 @@ const ArkMaterialGroup = ({
 	groups,
 	resources,
 	adjustStockItem,
+	setStockItem,
 	item_scale,
 	filter,
 	filter_type,
@@ -30,28 +32,34 @@ const ArkMaterialGroup = ({
 							{
 								list.map((index) => (
 									Boolean(filter ? filter(resources[index]) : true) && (
-										<div
-											key={resources[index].id}
-											class={style.material_group_item}
-											onClick={e => {
-												e.preventDefault();
-												e.stopPropagation();
-												adjustStockItem(resources[index].id, e.shiftKey ? 10 : 1);
-											}}
-											onContextMenu={e => {
-												e.preventDefault();
-												e.stopPropagation();
-												adjustStockItem(resources[index].id, e.shiftKey ? -10 : -1);
-											}}
-										>
-											<ArkItem
-												id={resources[index].id}
-												tier={resources[index].tier}
-												scale={item_scale}
-												quantity={stock[resources[index].id] || 0}
-												requirement={summary[resources[index].id] || 0}
-												show_exceeded={filter_type === 'exceeded'}
-											/>
+										<div class={style.material_group_item}>
+											<div
+												key={resources[index].id}
+												class={style.material_group_item_icon}
+												onClick={e => {
+													e.preventDefault();
+													e.stopPropagation();
+													adjustStockItem(resources[index].id, e.shiftKey ? 10 : 1);
+												}}
+												onContextMenu={e => {
+													e.preventDefault();
+													e.stopPropagation();
+													adjustStockItem(resources[index].id, e.shiftKey ? -10 : -1);
+												}}
+											>
+												<ArkItem
+													id={resources[index].id}
+													tier={resources[index].tier}
+													scale={item_scale}
+													requirement={summary[resources[index].id] || 0}
+													show_exceeded={filter_type === 'exceeded'}
+												/>
+											</div>
+											<ArkInputCell
+												name={resources[index]}
+												value={stock[resources[index].id] || 0}
+												onChange={quantity => setStockItem(resources[index].id, quantity)}
+												tabIndex={index} />
 										</div>
 									)))
 							}

--- a/src/components/materialsGroup/index.js
+++ b/src/components/materialsGroup/index.js
@@ -51,6 +51,7 @@ const ArkMaterialGroup = ({
 													id={resources[index].id}
 													tier={resources[index].tier}
 													scale={item_scale}
+													// quantity={stock[resources[index].id] || 0}
 													requirement={summary[resources[index].id] || 0}
 													show_exceeded={filter_type === 'exceeded'}
 												/>
@@ -59,7 +60,8 @@ const ArkMaterialGroup = ({
 												name={resources[index]}
 												value={stock[resources[index].id] || 0}
 												onChange={quantity => setStockItem(resources[index].id, quantity)}
-												tabIndex={index} />
+												tabIndex={index}
+											/>
 										</div>
 									)))
 							}

--- a/src/components/materialsGroup/style.css
+++ b/src/components/materialsGroup/style.css
@@ -28,11 +28,17 @@
 }
 
 .material_group_item {
-	width: 84px;
-	height: 96px;
+	width: 106px;
+	height: 128px;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	flex-direction: column;
+	margin-top: 6px;
+}
+
+.material_group_item_icon {
+	margin-bottom: 12px;
 }
 
 @media screen and (max-width: 600px) {

--- a/src/routes/farming/index.js
+++ b/src/routes/farming/index.js
@@ -53,6 +53,7 @@ const ArkFarming = ({
 		state: { stock, records, compound_materials },
 		load,
 		adjustStockItem,
+		setStockItem,
 	} = data;
 
 	const summary = useMemo(() => sumRequirements(records, stock, compound_materials), [records, stock, compound_materials]);
@@ -169,6 +170,7 @@ const ArkFarming = ({
 									resources={level_drop_resources.resources}
 									item_scale={item_scale}
 									adjustStockItem={adjustStockItem}
+									setStockItem={setStockItem}
 									groups={{
 										normal_drop: { render: 'farming-drop-normal_drop', list: level_drop_resources.normal_drop },
 										special_drop: { render: 'farming-drop-special_drop', list: level_drop_resources.special_drop },
@@ -237,6 +239,7 @@ const ArkFarming = ({
 							resources={material_list}
 							item_scale={item_scale}
 							adjustStockItem={adjustStockItem}
+							setStockItem={setStockItem}
 							groups={material_grouping_options[grouping_type].groups}
 							filter={itemFilter}
 							filter_type={filter_type}

--- a/src/routes/stock/index.js
+++ b/src/routes/stock/index.js
@@ -19,6 +19,7 @@ const ArkStockView = ({
 		state: { stock },
 		load,
 		adjustStockItem,
+		setStockItem,
 	} = data;
 
 	const [grouping_type, setGroupingType_raw] = useState(global.grouping_type || 'default');
@@ -83,6 +84,7 @@ const ArkStockView = ({
 							resources={sorted_material_list_by_locale[ir.locale] || material_list}
 							item_scale={item_scale}
 							adjustStockItem={adjustStockItem}
+							setStockItem={setStockItem}
 							groups={material_grouping_options_by_locale[ir.locale][grouping_type].groups}
 						/>
 					</div>


### PR DESCRIPTION
## About

This allows changing the amount of each material in stock even on the Stock page.

Take this as a suggestion with code.
In case that you don't like this, it's no problem to reject this. 🙂 

## Motivation

It already can be done at the header row in the Table page, but the table is too wide and a little bit difficult to find a material to change.

In the Stock page, I know that I can increase or decrease the amount by 1 (or 10) by clicking icons, however, it's not available on smartphones and also on PC without a mouse.

Besides that, for materials with large amounts, such as LMD, it is not practical to adjust the value by clicking. (ref #46)

## Screenshot

<img width="1074" alt="Screen Shot 2021-12-17 at 10 03 40" src="https://user-images.githubusercontent.com/62237356/146471685-ae8cd3ff-a8eb-4819-816c-17c6b5e8ae4f.png">
