### PR TITLE
  Bugfix at issue #63: Sync elite level when updating master skill in processUpgrade.js

### DIFF
--- a/src/routes/operator/hooks/processUpgrade.js
+++ b/src/routes/operator/hooks/processUpgrade.js
@@ -33,11 +33,6 @@ const processUpgrade = ({
 		// Elite rank
 		current_elite = clampRange(current_elite, 0, operator.meta.max_elite_rank);
 		target_elite = clampRange(target_elite, current_elite, operator.meta.max_elite_rank);
-		const elite_rank_change = target_elite !== current_elite;
-
-		// Level
-		current_level = clampRange(current_level, 1, exp.maxLevel[operator.rarity][current_elite]);
-		target_level = clampRange(target_level, elite_rank_change ? 1 : current_level, exp.maxLevel[operator.rarity][target_elite]);
 
 		// Skill level
 		current_all_skill = clampRange(current_all_skill, 1, 7);
@@ -109,7 +104,12 @@ const processUpgrade = ({
 			current_advanced_equipment_1 = 0;
 			target_advanced_equipment_1 = 0;
 		}
-		
+
+		const elite_rank_change = target_elite !== current_elite;
+
+		// Level
+		current_level = clampRange(current_level, 1, exp.maxLevel[operator.rarity][current_elite]);
+		target_level = clampRange(target_level, elite_rank_change ? 1 : current_level, exp.maxLevel[operator.rarity][target_elite]);
 
 		// level
 		if (elite_rank_change) {


### PR DESCRIPTION
https://github.com/Houdou/arkgraph/issues/63 で報告されているバグを修正します。

## 詳細

元々のprocessUpgrade.js では `elite_rank_change` を宣言した後に `target_elite` を変更している箇所があるため (79行目など) 、変更が反映されていませんでした。

`target_elite` の変更が終わった後に `elite_rank_change` を宣言するように移動します。

-----------------

機械翻訳 ↓

修复在 https://github.com/Houdou/arkgraph/issues/63 报告的bug。

## 详细信息

原本的processUpgrade.js中，在声明elite_rank_change后修改了target_elite（例如第79行），因此更改没有反映出来。

将声明elite_rank_change的代码移动到target_elite的修改完成后。
